### PR TITLE
Fix Fatal error: Class 'HTML' not found in install/views/form.php line 1...

### DIFF
--- a/install/views/form.php
+++ b/install/views/form.php
@@ -149,7 +149,7 @@
                     <div class="col-sm-12">
                     <div class="checkbox">
                     <label>
-                        <input type="checkbox" name="DB_CREATE" data-toggle="tooltip" title="<?=HTML::chars(__("Will try to create the DB if doesn't exists. Root permissions required."))?>" />
+                        <input type="checkbox" name="DB_CREATE" data-toggle="tooltip" title="<?=__("Will try to create the DB if doesn't exists. Root permissions required.")?>" />
                                 <?=__("Create DB.")?>
                                 <br>
                                 


### PR DESCRIPTION
Fix Bug/Regression after Merge pull request #280 from emanwebdev/html_fixes ( committed here: https://github.com/open-classifieds/open-eshop/commit/98fbe727141620a6b208d04b3f49900d2887a565 ) 

Fix Fatal error: Class 'HTML' not found in /open-eshop/install/views/form.php on line _152_
