### PR TITLE
[NEW] [oc-panel] Sub-Menu for Cache Menu: 1-click Cache Clear

### DIFF
--- a/themes/default/views/oc-panel/header.php
+++ b/themes/default/views/oc-panel/header.php
@@ -21,8 +21,17 @@
                     <?=Theme::admin_link(__('Support'), 'support','index','oc-panel','glyphicon glyphicon-comment')?>
                 	<?=Theme::admin_link(__('Stats'),'stats','index','oc-panel','glyphicon glyphicon-align-left')?>
                     <?=Theme::admin_link(__('Widgets'),'widget','index','oc-panel','glyphicon glyphicon-move')?>
-                    <?=Theme::admin_link(__('Cache'),'tools','cache','oc-panel','glyphicon glyphicon-cog')?>
-                    <? if(Auth::instance()->get_user()->id_role==Model_Role::ROLE_ADMIN):?>
+                    <li class="dropdown">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                            <i class="glyphicon glyphicon-cog"></i> <?=__('Cache')?> <b class="caret"></b>
+                        </a>
+                        <ul class="dropdown-menu">
+                            <?=Theme::admin_link(__('Cache'),'tools','cache','oc-panel','glyphicon glyphicon-cog')?>
+                            <?=Theme::admin_link(__('Delete all'),'tools','cache?force=1','oc-panel','glyphicon glyphicon-remove-sign')?>
+                            <?=Theme::admin_link(__('Delete expired'),'tools','cache?force=2','oc-panel','glyphicon glyphicon-remove-circle')?>
+                        </ul>
+                    </li>
+                    <? if(Auth::instance()->get_user()->id_role===Model_Role::ROLE_ADMIN):?>
             	    <li  class="dropdown "><a href="#" class="dropdown-toggle"
             		      data-toggle="dropdown"><i class="glyphicon glyphicon-plus"></i> <?=__('New')?> <b class="caret"></b></a>
                     	<ul class="dropdown-menu">


### PR DESCRIPTION
NOTICE: don't forget to hold Shift when clicking on these 2 new links :^# (or we add a `target="_blank"` to `Theme::admin_link` and `themes/default/views/oc-panel/admin_link.php` ?

Possible Nice to Have enhancement: AJAX based instead of opening new oc-panel page
